### PR TITLE
Fix invalid TS/TSX identifiers for hyphenated component filenames

### DIFF
--- a/packages/uifork/cli.js
+++ b/packages/uifork/cli.js
@@ -6,6 +6,7 @@ const { UISwitcherScaffold } = require("./lib/init");
 const { VersionSync } = require("./lib/watch");
 const { VersionPromoter } = require("./lib/promote");
 const { findComponentManager } = require("./lib/cli-helpers");
+const { getVersionComponentIdentifier } = require("./lib/component-naming");
 
 function showHelp() {
   console.log(`
@@ -230,8 +231,7 @@ switch (command) {
 
       const displayVersion = targetVersion.replace(/^v/, "").replace(/_/g, ".").toUpperCase();
 
-      const importSuffix = manager.versionToImportSuffix(fileVersion);
-      const componentName = `${manager.componentName}${importSuffix}`;
+      const componentName = getVersionComponentIdentifier(manager.componentName, fileVersion);
 
       let templateContent;
       if (extension === ".tsx" || extension === ".jsx") {
@@ -413,10 +413,11 @@ export default function ${componentName}() {
 
       const sourceContent = fs.readFileSync(sourceFilePath, "utf8");
 
-      const importSuffix = manager.versionToImportSuffix(fileVersion);
-      const newImportSuffix = manager.versionToImportSuffix(targetFileVersion);
-      const oldComponentName = `${manager.componentName}${importSuffix}`;
-      const newComponentName = `${manager.componentName}${newImportSuffix}`;
+      const oldComponentName = getVersionComponentIdentifier(manager.componentName, fileVersion);
+      const newComponentName = getVersionComponentIdentifier(
+        manager.componentName,
+        targetFileVersion,
+      );
 
       const updatedContent = sourceContent.replace(
         new RegExp(oldComponentName, "g"),

--- a/packages/uifork/lib/component-naming.js
+++ b/packages/uifork/lib/component-naming.js
@@ -1,0 +1,30 @@
+function toPascalCaseIdentifier(name) {
+  const chunks = String(name || "").match(/[a-zA-Z0-9]+/g) || [];
+  const identifier = chunks
+    .map((chunk) => `${chunk.charAt(0).toUpperCase()}${chunk.slice(1)}`)
+    .join("");
+
+  if (!identifier) {
+    return "Component";
+  }
+
+  if (!/^[A-Za-z_$]/.test(identifier)) {
+    return `Component${identifier}`;
+  }
+
+  return identifier;
+}
+
+function versionToImportSuffix(versionStr) {
+  return `V${versionStr.charAt(0).toUpperCase()}${versionStr.slice(1)}`;
+}
+
+function getVersionComponentIdentifier(componentName, versionStr) {
+  return `${toPascalCaseIdentifier(componentName)}${versionToImportSuffix(versionStr)}`;
+}
+
+module.exports = {
+  getVersionComponentIdentifier,
+  toPascalCaseIdentifier,
+  versionToImportSuffix,
+};

--- a/packages/uifork/lib/init.js
+++ b/packages/uifork/lib/init.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const { VersionSync } = require("./watch");
+const { toPascalCaseIdentifier } = require("./component-naming");
 
 class UISwitcherScaffold {
   constructor(filePath, shouldWatch = true) {
@@ -14,6 +15,7 @@ class UISwitcherScaffold {
 
     const parsedPath = path.parse(this.originalFilePath);
     this.componentName = parsedPath.name;
+    this.componentIdentifier = toPascalCaseIdentifier(this.componentName);
     this.parentDir = parsedPath.dir;
     this.originalExtension = parsedPath.ext; // Preserve .tsx or .ts
     this.v1File = path.join(this.parentDir, `${this.componentName}.v1${this.originalExtension}`);
@@ -38,11 +40,11 @@ class UISwitcherScaffold {
  * Manual edits to labels/descriptions are preserved, but structure changes may be overwritten.
  * To stop versioning this component, run: npx uifork promote ${this.componentName} <version-id>
  */
-import ${this.componentName}V1 from "${v1ImportPath}"
+import ${this.componentIdentifier}V1 from "${v1ImportPath}"
 
 export const VERSIONS = {
   "v1": {
-    render: ${this.componentName}V1,
+    render: ${this.componentIdentifier}V1,
     label: "",
   },
 }
@@ -65,7 +67,7 @@ export const VERSIONS = {
 import { ForkedComponent } from "uifork"
 import { VERSIONS } from "${versionsImportPath}"
 
-export default function ${this.componentName}(props: any) {
+export default function ${this.componentIdentifier}(props: any) {
   return (
     <ForkedComponent
       id="${this.componentName}"
@@ -124,7 +126,7 @@ export { VERSIONS }
         `4. Add new versions by creating ${this.componentName}.v2${this.originalExtension}, ${this.componentName}.v1_1${this.originalExtension}, etc.`,
       );
       console.log(
-        `5. Import the component: import ${this.componentName} from './${this.componentName}'`,
+        `5. Import the component: import ${this.componentIdentifier} from './${this.componentName}'`,
       );
       // Start watching automatically
       new VersionSync(this.parentDir);
@@ -134,7 +136,7 @@ export { VERSIONS }
         `4. Add new versions by creating ${this.componentName}.v2${this.originalExtension}, ${this.componentName}.v1_1${this.originalExtension}, etc.`,
       );
       console.log(
-        `5. Import the component: import ${this.componentName} from './${this.componentName}'`,
+        `5. Import the component: import ${this.componentIdentifier} from './${this.componentName}'`,
       );
     }
   }


### PR DESCRIPTION
## Summary
This PR fixes an identifier-generation bug for component files whose base filename contains hyphens (for example `google-calendar-card-list.tsx`).

Previously, UIFork generated invalid TS/TSX identifiers such as:
- `google-calendar-card-listV2`

which breaks builds.

## Root Cause
Generator code used the raw filename-derived `componentName` directly in JavaScript/TypeScript identifiers across multiple flows (`init`, `new`, watch-server generation, rename, and promote).

## Changes
- Added a shared naming utility: `packages/uifork/lib/component-naming.js`
  - `toPascalCaseIdentifier(name)`
  - `versionToImportSuffix(versionStr)`
  - `getVersionComponentIdentifier(componentName, versionStr)`
- Updated `init` scaffolding (`packages/uifork/lib/init.js`) to generate:
  - wrapper default export function name as PascalCase identifier
  - `*.versions.ts` import alias and `render` binding with valid identifiers
  - next-step import example with valid identifier
- Updated CLI flows (`packages/uifork/cli.js`):
  - `new`: generated `*.vN.tsx` default export name now uses normalized identifier
  - `rename`: component symbol rename logic now targets normalized versioned identifiers
- Updated watch-server generation and WS actions (`packages/uifork/lib/watch.js`):
  - generated import aliases and `render` entries now use normalized identifiers
  - WS `new_version` and `rename_version` code paths now use normalized identifiers
- Updated promote flow (`packages/uifork/lib/promote.js`):
  - promoted wrapper keeps valid PascalCase default export name
  - includes compatibility replacement for legacy invalid names (`raw-nameV2`) during promotion

## Result
For `google-calendar-card-list.tsx`, UIFork now consistently generates:
- Wrapper: `export default function GoogleCalendarCardList(...)`
- Versions aliases/render: `GoogleCalendarCardListV1`, `GoogleCalendarCardListV2`, ...
- New version file default export: `GoogleCalendarCardListV2`

## Validation
Executed locally:
1. `node -c` syntax checks for modified CLI/lib files.
2. `npm run lint` (passes; only existing unrelated warnings in sandbox/marketing examples).
3. End-to-end manual flow on temp fixture `google-calendar-card-list.tsx`:
   - `uifork init`
   - `uifork new ... v2`
   - `uifork rename v2 v3`
   - `uifork promote ... v2`
   Verified generated identifiers are valid PascalCase in wrapper, `*.versions.ts`, and `*.vN.tsx` files.
