### PR TITLE
Fix bracket file names

### DIFF
--- a/packages/uifork/lib/cli-helpers.js
+++ b/packages/uifork/lib/cli-helpers.js
@@ -33,6 +33,22 @@ function findComponentManager(componentPath) {
     }
   }
 
+  // Path doesn't exist as-is — try treating it as a component reference
+  // e.g. "src/app/[orgSlug]/page" where "page.versions.ts" sits in that directory
+  // Only strip known source extensions; dots in names (e.g. Button.icon) are preserved
+  const dir = path.dirname(resolvedPath);
+  let baseName = path.basename(resolvedPath);
+  const ext = path.extname(baseName);
+  if ([".tsx", ".ts", ".jsx", ".js"].includes(ext)) {
+    baseName = baseName.slice(0, -ext.length);
+  }
+  if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) {
+    const versionsFile = path.join(dir, `${baseName}.versions.ts`);
+    if (fs.existsSync(versionsFile)) {
+      return new ComponentManager(versionsFile);
+    }
+  }
+
   // Try searching by component name
   if (!componentPath.includes("/") && !componentPath.includes("\\")) {
     const found = recursiveSearchVersionsFile(process.cwd(), componentPath);

--- a/packages/uifork/lib/promote.js
+++ b/packages/uifork/lib/promote.js
@@ -6,6 +6,10 @@ const {
   versionToImportSuffix,
 } = require("./component-naming");
 
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 class VersionPromoter {
   constructor(componentPath, versionId) {
     // Find the component directory and files
@@ -49,10 +53,9 @@ class VersionPromoter {
 
   extractComponentName(versionsFilePath) {
     const basename = path.basename(versionsFilePath, ".versions.ts");
-    // Remove file extension if present (e.g., "Component.tsx" -> "Component")
-    // Version files are named like "Component.v1.tsx", not "Component.tsx.v1.tsx"
+    // Only strip known source extensions; dots in names (e.g. Button.icon) are preserved
     const ext = path.extname(basename);
-    if (ext) {
+    if ([".tsx", ".ts", ".jsx", ".js"].includes(ext)) {
       return basename.slice(0, -ext.length);
     }
     return basename;
@@ -83,6 +86,22 @@ class VersionPromoter {
         if (fs.existsSync(versionsFile)) {
           return versionsFile;
         }
+      }
+    }
+
+    // Path doesn't exist as-is — try treating it as a component reference
+    // e.g. "src/app/[orgSlug]/page" where "page.versions.ts" sits in that directory
+    // Only strip known source extensions; dots in names (e.g. Button.icon) are preserved
+    const dir = path.dirname(resolvedPath);
+    let baseName = path.basename(resolvedPath);
+    const ext = path.extname(baseName);
+    if ([".tsx", ".ts", ".jsx", ".js"].includes(ext)) {
+      baseName = baseName.slice(0, -ext.length);
+    }
+    if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) {
+      const versionsFile = path.join(dir, `${baseName}.versions.ts`);
+      if (fs.existsSync(versionsFile)) {
+        return versionsFile;
       }
     }
 
@@ -150,7 +169,8 @@ class VersionPromoter {
 
   getAllVersionFiles() {
     const files = fs.readdirSync(this.watchDir);
-    const versionPattern = new RegExp(`^${this.componentName}\\.v([\\d_]+)\\.(tsx?|jsx?)$`);
+    const escaped = escapeRegExp(this.componentName);
+    const versionPattern = new RegExp(`^${escaped}\\.v([\\d_]+)\\.(tsx?|jsx?)$`);
     return files
       .filter((file) => {
         const match = file.match(versionPattern);

--- a/packages/uifork/lib/watch.js
+++ b/packages/uifork/lib/watch.js
@@ -12,6 +12,10 @@ const {
   versionToImportSuffix,
 } = require("./component-naming");
 
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
  * ComponentManager - Manages a single component's versions
  */
@@ -30,8 +34,9 @@ class ComponentManager {
 
   extractComponentName(versionsFilePath) {
     const basename = path.basename(versionsFilePath, ".versions.ts");
+    // Only strip known source extensions; dots in names (e.g. Button.icon) are preserved
     const ext = path.extname(basename);
-    if (ext) {
+    if ([".tsx", ".ts", ".jsx", ".js"].includes(ext)) {
       return basename.slice(0, -ext.length);
     }
     return basename;
@@ -39,7 +44,8 @@ class ComponentManager {
 
   getVersionFiles() {
     const files = fs.readdirSync(this.watchDir);
-    const versionPattern = new RegExp(`^${this.componentName}\\.v([\\d_]+)\\.(tsx?|jsx?)$`);
+    const escaped = escapeRegExp(this.componentName);
+    const versionPattern = new RegExp(`^${escaped}\\.v([\\d_]+)\\.(tsx?|jsx?)$`);
     const matchedFiles = files
       .filter((file) => {
         const match = file.match(versionPattern);
@@ -72,7 +78,8 @@ class ComponentManager {
 
   getVersionKeys() {
     const versionFiles = this.getVersionFiles();
-    const versionPattern = new RegExp(`^${this.componentName}\\.v([\\d_]+)`);
+    const escaped = escapeRegExp(this.componentName);
+    const versionPattern = new RegExp(`^${escaped}\\.v([\\d_]+)`);
     return versionFiles
       .map((file) => {
         const match = file.match(versionPattern);
@@ -98,7 +105,8 @@ class ComponentManager {
   }
 
   generateImportName(fileName) {
-    const versionPattern = new RegExp(`^${this.componentName}\\.v([\\d_]+)`);
+    const escaped = escapeRegExp(this.componentName);
+    const versionPattern = new RegExp(`^${escaped}\\.v([\\d_]+)`);
     const match = fileName.match(versionPattern);
     if (!match) return null;
     const versionStr = match[1];
@@ -106,7 +114,8 @@ class ComponentManager {
   }
 
   generateVersionKey(fileName) {
-    const versionPattern = new RegExp(`^${this.componentName}\\.v([\\d_]+)`);
+    const escaped = escapeRegExp(this.componentName);
+    const versionPattern = new RegExp(`^${escaped}\\.v([\\d_]+)`);
     const match = fileName.match(versionPattern);
     if (!match) return null;
     return `v${match[1]}`;
@@ -144,7 +153,8 @@ class ComponentManager {
       return { major: 1, minor: 0 };
     }
 
-    const versionPattern = new RegExp(`^${this.componentName}\\.v([\\d_]+)`);
+    const escaped = escapeRegExp(this.componentName);
+    const versionPattern = new RegExp(`^${escaped}\\.v([\\d_]+)`);
     let maxMajor = 0;
     let maxMinor = 0;
 
@@ -268,7 +278,8 @@ class ComponentManager {
     const versionFiles = this.getVersionFiles();
 
     this.currentVersionFiles = new Set(versionFiles);
-    const versionPattern = new RegExp(`^${this.componentName}\\.v([\\d_]+)`);
+    const escaped = escapeRegExp(this.componentName);
+    const versionPattern = new RegExp(`^${escaped}\\.v([\\d_]+)`);
     this.currentVersionKeys = new Set(
       versionFiles
         .map((file) => {
@@ -389,8 +400,9 @@ ${versions},
       if (removed.length === 1 && added.length === 1) {
         const oldFile = removed[0];
         const newFile = added[0];
-        const oldMatch = oldFile.match(new RegExp(`^${this.componentName}\\.v([\\d_]+)`));
-        const newMatch = newFile.match(new RegExp(`^${this.componentName}\\.v([\\d_]+)`));
+        const escaped = escapeRegExp(this.componentName);
+        const oldMatch = oldFile.match(new RegExp(`^${escaped}\\.v([\\d_]+)`));
+        const newMatch = newFile.match(new RegExp(`^${escaped}\\.v([\\d_]+)`));
         if (oldMatch && newMatch) {
           const oldKey = `v${oldMatch[1]}`;
           const newKey = `v${newMatch[1]}`;
@@ -1261,6 +1273,7 @@ export default function ${componentName}() {
       ignored: [/node_modules/, /^\./],
       persistent: true,
       ignoreInitial: true,
+      disableGlobbing: true,
     });
 
     watcher
@@ -1310,7 +1323,8 @@ export default function ${componentName}() {
 
     // Find which component this file belongs to
     for (const [name, manager] of this.components) {
-      const versionPattern = new RegExp(`^${manager.componentName}\\.v([\\d_]+)\\.(tsx?|jsx?)$`);
+      const escaped = escapeRegExp(manager.componentName);
+      const versionPattern = new RegExp(`^${escaped}\\.v([\\d_]+)\\.(tsx?|jsx?)$`);
       const isVersionFile = versionPattern.test(filename);
       const isVersionsFile = filename === `${manager.componentName}.versions.ts`;
 


### PR DESCRIPTION
Closes #3 

# Test Cases

Verifies that the CLI works correctly with Next.js dynamic route brackets,
standard Next.js paths, and Vite project paths.

---

## Setup

Each test case describes a directory layout and a set of CLI commands to run.
Expected results are listed after each command.

---

## 1. Next.js App Router — Dynamic Route (brackets)

### Directory layout

```
my-nextjs-app/
└── src/app/creators/[orgSlug]/
    ├── page.tsx
    ├── page.versions.ts
    ├── page.v1.tsx
    ├── page.v2.tsx
    └── page.UISwitcher.tsx
```

### 1a. `promote` with quoted bracket path

```bash
cd my-nextjs-app
npx uifork promote "src/app/creators/[orgSlug]/page" v2
```

**Expected:** Promotes v2 successfully. `page.tsx` is replaced with v2 content.
All version files (`page.v1.tsx`, `page.v2.tsx`, `page.versions.ts`,
`page.UISwitcher.tsx`) are deleted.

### 1b. `promote` with `.tsx` extension

```bash
npx uifork promote "src/app/creators/[orgSlug]/page.tsx" v1
```

**Expected:** Same as 1a but promotes v1.

### 1c. `promote` pointing to the versions file directly

```bash
npx uifork promote "src/app/creators/[orgSlug]/page.versions.ts" v2
```

**Expected:** Works — the versions file path is used directly.

### 1d. `watch` with bracket path

```bash
npx uifork watch "src/app/creators/[orgSlug]"
```

**Expected:** Watch server starts, discovers `page` component, lists its
versions. Chokidar does NOT interpret `[orgSlug]` as a glob character class.

### 1e. `new` / `fork` / `delete` / `rename` via CLI

```bash
npx uifork new "src/app/creators/[orgSlug]/page"
npx uifork fork "src/app/creators/[orgSlug]/page" v1
npx uifork delete "src/app/creators/[orgSlug]/page" v1
npx uifork rename "src/app/creators/[orgSlug]/page" v2 v5
```

**Expected:** Each command resolves the versions file correctly and succeeds.

---

## 2. Next.js App Router — Nested Dynamic Routes (multiple brackets)

### Directory layout

```
my-nextjs-app/
└── src/app/[locale]/dashboard/[teamId]/
    ├── settings.tsx
    ├── settings.versions.ts
    ├── settings.v1.tsx
    └── settings.v2.tsx
```

### 2a. `promote` through two bracket segments

```bash
npx uifork promote "src/app/[locale]/dashboard/[teamId]/settings" v1
```

**Expected:** Resolves `settings.versions.ts` in the `[teamId]` directory and
promotes v1.

### 2b. `watch` at project root picks up nested bracket paths

```bash
npx uifork watch
```

**Expected:** Discovers `settings` component inside
`src/app/[locale]/dashboard/[teamId]/`. File changes in that directory are
detected by chokidar without glob misinterpretation.

---

## 3. Next.js App Router — Standard Path (no brackets)

### Directory layout

```
my-nextjs-app/
└── src/app/about/
    ├── page.tsx
    ├── page.versions.ts
    ├── page.v1.tsx
    └── page.v2.tsx
```

### 3a. `promote` without extension

```bash
npx uifork promote src/app/about/page v2
```

**Expected:** Works — no quoting needed since there are no special characters.

### 3b. `promote` with extension

```bash
npx uifork promote src/app/about/page.tsx v1
```

**Expected:** Works.

### 3c. `promote` by directory

```bash
npx uifork promote src/app/about v1
```

**Expected:** Finds `page.versions.ts` inside the `about/` directory and
promotes v1.

---

## 4. Vite + React Project

### Directory layout

```
my-vite-app/
└── src/components/PricingCard/
    ├── PricingCard.tsx
    ├── PricingCard.versions.ts
    ├── PricingCard.v1.tsx
    ├── PricingCard.v2.tsx
    └── PricingCard.UISwitcher.tsx
```

### 4a. `promote` by directory

```bash
cd my-vite-app
npx uifork promote src/components/PricingCard v2
```

**Expected:** Finds `PricingCard.versions.ts` in the directory and promotes v2.

### 4b. `promote` by file path (no extension)

```bash
npx uifork promote src/components/PricingCard/PricingCard v1
```

**Expected:** Resolves `PricingCard.versions.ts` in the same directory.

### 4c. `promote` by file path (with extension)

```bash
npx uifork promote src/components/PricingCard/PricingCard.tsx v1
```

**Expected:** Works.

### 4d. `promote` by component name only

```bash
npx uifork promote PricingCard v2
```

**Expected:** Recursively searches from cwd, finds `PricingCard.versions.ts`,
and promotes v2.

### 4e. `watch` at project root

```bash
npx uifork watch
```

**Expected:** Discovers `PricingCard` component. Adding/removing/renaming
version files triggers regeneration of `PricingCard.versions.ts`.

---

## 5. Edge Cases

### 5a. Component name with dots (e.g. `Button.icon`)

```
src/components/Button.icon.tsx
src/components/Button.icon.versions.ts
src/components/Button.icon.v1.tsx
```

```bash
npx uifork promote src/components/Button.icon v1
```

**Expected:** The dot in the component name is escaped in regex patterns and
does not match arbitrary characters.

### 5b. Bracket characters in component name (unlikely but valid)

```
src/components/[Slot].tsx
src/components/[Slot].versions.ts
src/components/[Slot].v1.tsx
```

```bash
npx uifork promote "src/components/[Slot]" v1
```

**Expected:** Brackets in the component name are escaped in regex patterns.
`[Slot]` is NOT interpreted as a character class matching `S`, `l`, `o`, `t`.

### 5c. Path without quotes in zsh (shell glob expansion)

```bash
npx uifork promote src/app/creators/[orgSlug]/page v1
```

**Expected (bash):** Shell passes the literal string since `[orgSlug]` matches
no files as a glob. Command works.

**Expected (zsh, default `nomatch`):** zsh prints
`zsh: no matches found: src/app/creators/[orgSlug]/page`. This is a shell-level
issue, not a uifork bug. Users must quote the path in zsh.

### 5d. Nonexistent path

```bash
npx uifork promote "src/does/not/exist/page" v1
```

**Expected:** Clear error: `Versions file not found for: src/does/not/exist/page`.
